### PR TITLE
Adapt to new org.apache.commons.commons-io package name #367033

### DIFF
--- a/h1modulesfeature/feature.xml
+++ b/h1modulesfeature/feature.xml
@@ -105,9 +105,9 @@ To apply the Apache License to your work, attach the following boilerplate notic
       <import plugin="org.eclipse.ui.console" version="3.6.201" match="greaterOrEqual"/>
       <import plugin="org.eclipse.debug.core"/>
       <import plugin="org.eclipse.jdt.launching"/>
-      <import plugin="org.apache.commons.io"/>
+      <import plugin="org.apache.commons.commons-io"/>
       <import plugin="org.eclipse.team.ui"/>
-      <import plugin="org.apache.commons.io" version="2.2.0" match="greaterOrEqual"/>
+      <import plugin="org.apache.commons.commons-io" version="2.2.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.equinox.p2.core"/>
       <import plugin="org.eclipse.equinox.p2.engine"/>
       <import plugin="org.eclipse.equinox.p2.metadata"/>

--- a/net.sf.ecl1.import.wizard/META-INF/MANIFEST.MF
+++ b/net.sf.ecl1.import.wizard/META-INF/MANIFEST.MF
@@ -7,10 +7,10 @@ Bundle-Vendor: HIS eG
 Require-Bundle: org.eclipse.ui,
  net.sf.ecl1.utilities,
  org.eclipse.jgit,
- com.google.guava;bundle-version="15.0.0",
- org.apache.commons.io;bundle-version="2.2.0"
+ com.google.guava;bundle-version="15.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .
 Bundle-Activator: net.sf.ecl1.importwizard.Activator
 Bundle-ActivationPolicy: lazy
-Import-Package: com.google.gson;version="[2.13.0,3.0.0)"
+Import-Package: org.apache.commons.io,
+ com.google.gson;version="[2.13.0,3.0.0)"


### PR DESCRIPTION
The package name 'org.apache.commons.io' is not available anymore, so we need to adapt to the new name 'org.apache.commons.commons-io'

This fixes the installation of ECL1 on newer fresh Eclipse versions.